### PR TITLE
include undefined  description parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It's simple as this:
 ```
 npm install -g clockified-worker
 
-clockified --workspaceId your_workspace_id --projectId your_project_id --startFrom 2019-05-04 --untilTo 2019-05-31 --apiKey your_api_key
+clockified --workspaceId your_workspace_id --projectId your_project_id --description your_job_description --startFrom 2019-05-04 --untilTo 2019-05-31 --apiKey your_api_key
 ```
 
 If you need help, just type:

--- a/bin/clockified
+++ b/bin/clockified
@@ -15,6 +15,11 @@ argv.option([
         description: 'Project ID'
     },
     {
+        name: 'description',
+        type: 'string',
+        description: 'Description of what you are working.'
+    },
+    {
         name: 'apiKey',
         description: 'API Key',
         type: 'string'


### PR DESCRIPTION
This pull request fix the undefined description parameter.
When you pointing hours using clockified the field description on clockify was be "undefined", because the parameter "description" does not exists.